### PR TITLE
Floating point and long metrics support [BREAKING CHANGE]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,15 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+		    </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>2.1.2</version>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>com.zanox.lib.simplegraphiteclient</groupId>
 	<artifactId>simplegraphiteclient</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.0</version>
+	<version>2.0.0-SNAPSHOT</version>
 	
 	<description>Simple java client for sending metrics to graphite.</description>
 	<url>https://github.com/zanox/simplegraphiteclient</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>com.zanox.lib.simplegraphiteclient</groupId>
 	<artifactId>simplegraphiteclient</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.1</version>
+	<version>2.1.0-SNAPSHOT</version>
 	
 	<description>Simple java client for sending metrics to graphite.</description>
 	<url>https://github.com/zanox/simplegraphiteclient</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>com.zanox.lib.simplegraphiteclient</groupId>
 	<artifactId>simplegraphiteclient</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.0</version>
+	<version>2.1.0-SNAPSHOT</version>
 	
 	<description>Simple java client for sending metrics to graphite.</description>
 	<url>https://github.com/zanox/simplegraphiteclient</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>com.zanox.lib.simplegraphiteclient</groupId>
 	<artifactId>simplegraphiteclient</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0</version>
 	
 	<description>Simple java client for sending metrics to graphite.</description>
 	<url>https://github.com/zanox/simplegraphiteclient</url>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>com.zanox.lib.simplegraphiteclient</groupId>
 	<artifactId>simplegraphiteclient</artifactId>
 	<packaging>jar</packaging>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.0.1</version>
 	
 	<description>Simple java client for sending metrics to graphite.</description>
 	<url>https://github.com/zanox/simplegraphiteclient</url>

--- a/src/main/java/com/zanox/lib/simplegraphiteclient/SimpleGraphiteClient.java
+++ b/src/main/java/com/zanox/lib/simplegraphiteclient/SimpleGraphiteClient.java
@@ -35,7 +35,7 @@ public class SimpleGraphiteClient {
 	 *  
 	 * @param metrics the metrics as key-value-pairs
 	 */
-	public void sendMetrics(Map<String, Integer> metrics) {
+	public void sendMetrics(Map<String, Number> metrics) {
 		sendMetrics(metrics, getCurrentTimestamp());
 	}
 
@@ -45,13 +45,13 @@ public class SimpleGraphiteClient {
 	 * @param metrics the metrics as key-value-pairs
 	 * @param timeStamp the timestamp
 	 */
-	public void sendMetrics(Map<String, Integer> metrics, long timeStamp) {
+	public void sendMetrics(Map<String, Number> metrics, long timeStamp) {
 		try {
 			Socket socket = createSocket();
 			OutputStream s = socket.getOutputStream();
 			PrintWriter out = new PrintWriter(s, true);
-			for (Map.Entry<String, Integer> metric: metrics.entrySet()) {
-				out.printf("%s %d %d%n", metric.getKey(), metric.getValue(), timeStamp);	
+			for (Map.Entry<String, Number> metric: metrics.entrySet()) {
+				out.printf("%s %s %d%n", metric.getKey(), metric.getValue(), timeStamp);	
 			}			
 			out.close();
 			socket.close();
@@ -85,7 +85,7 @@ public class SimpleGraphiteClient {
 	 */
 	@SuppressWarnings("serial")
 	public void sendMetric(final String key, final int value, long timeStamp) {		
-		sendMetrics(new HashMap<String, Integer>() {{
+		sendMetrics(new HashMap<String, Number>() {{
 			put(key, value);
 		}}, timeStamp);
 	}

--- a/src/main/java/com/zanox/lib/simplegraphiteclient/SimpleGraphiteClient.java
+++ b/src/main/java/com/zanox/lib/simplegraphiteclient/SimpleGraphiteClient.java
@@ -70,7 +70,7 @@ public class SimpleGraphiteClient {
 	 * 
 	 * @throws GraphiteException if writing to graphite fails
 	 */
-	public void sendMetric(String key, int value) {
+	public void sendMetric(String key, Number value) {
 		sendMetric(key, value, getCurrentTimestamp());
 	}
 	
@@ -84,7 +84,7 @@ public class SimpleGraphiteClient {
 	 * @throws GraphiteException if writing to graphite fails 
 	 */
 	@SuppressWarnings("serial")
-	public void sendMetric(final String key, final int value, long timeStamp) {		
+	public void sendMetric(final String key, final Number value, long timeStamp) {		
 		sendMetrics(new HashMap<String, Number>() {{
 			put(key, value);
 		}}, timeStamp);

--- a/src/test/java/com/zanox/lib/simplegraphiteclient/SimpleGraphiteClientTest.java
+++ b/src/test/java/com/zanox/lib/simplegraphiteclient/SimpleGraphiteClientTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,13 +63,29 @@ public class SimpleGraphiteClientTest {
 	
 	@Test
 	public void testSendMultipleMetrics() {
-		Map<String, Integer> data = new  HashMap<String, Integer>();
+		Map<String, Number> data = new  HashMap<String, Number>();
 		data.put("junit.test.metric1", 4711);
 		data.put("junit.test.metric2", 4712);
 		simpleGraphiteClient.sendMetrics(data);
 		assertTrue(out.toString().contains("junit.test.metric1 4711 " + currentTimestamp));
 		assertTrue(out.toString().contains("junit.test.metric2 4712 " + currentTimestamp));
 	}
+	
+	   @Test
+	    public void testSendFloatingPointAndLongMetrics() {
+	        Map<String, Number> data = new  HashMap<String, Number>();
+	        data.put("junit.test.metric1", 4711);
+	        data.put("junit.test.metric2", 4712.333);
+	        data.put("junit.test.metric3", 4712324723874687236L);
+	        data.put("junit.test.metric4", new BigDecimal(3.34, new MathContext(3)));
+	        data.put("junit.test.metric5", 4.89767324);
+	        simpleGraphiteClient.sendMetrics(data);
+	        assertTrue(out.toString().contains("junit.test.metric1 4711 " + currentTimestamp));
+	        assertTrue(out.toString().contains("junit.test.metric2 4712.333 " + currentTimestamp));
+	        assertTrue(out.toString().contains("junit.test.metric3 4712324723874687236 " + currentTimestamp));
+	        assertTrue(out.toString().contains("junit.test.metric4 3.34 " + currentTimestamp));
+	        assertTrue(out.toString().contains("junit.test.metric5 4.89767324 " + currentTimestamp));
+	    }
 	
 	@Test
 	public void testCurrentTimestamp() {


### PR DESCRIPTION
Implemented floating point and long metric types support.

Breaks SimpleGraphiteClient.sendMetrics methods because the map is now differently parametrized.
Map\<String, Integer\> became Map\<String, Number\>

https://github.com/zanox/simplegraphiteclient/compare/master...dpoldrugo:dpoldrugo-Floating-point-and-long-metrics-support#diff-af42b0b0992ff4b83875d6f6b08dc0d8R38

https://github.com/zanox/simplegraphiteclient/compare/master...dpoldrugo:dpoldrugo-Floating-point-and-long-metrics-support#diff-af42b0b0992ff4b83875d6f6b08dc0d8R48